### PR TITLE
Add source layer for vector sources

### DIFF
--- a/R/layers_circle.R
+++ b/R/layers_circle.R
@@ -39,6 +39,7 @@ add_circle_layer <- function(map,
                              circle_translate_anchor = NULL,
                              visibility = TRUE,
                              popup = NULL,
+                             source_layer = NULL,
                              id = "circle-layer") {
   paint <- list(
     "circle-blur" = circle_blur,
@@ -58,7 +59,7 @@ add_circle_layer <- function(map,
     "circle-sort-key" = circle_sort_key,
     "visibility" = ifelse(visibility, "visible", "none")
   )
-  style <- create_layer_style(id, "circle", source, filter, paint, layout)
+  style <- create_layer_style(id, "circle", source, filter, paint, layout, source_layer)
   map %>%
     add_layer(style, popup)
 }

--- a/R/layers_fill.R
+++ b/R/layers_fill.R
@@ -1,5 +1,6 @@
 #' Add a fill layer to the map
 #' @param source A Mapbox source. Uses the source from the \link{mapboxer} object if no source is supplied.
+#' @param source_layer The layer to use in the source for vector sources..
 #' @param filter A filter expression that is applied to the \code{source}.
 #' @param fill_antialias (paint) Whether or not the fill should be antialiased.
 #' @param fill_color (paint) The color of the filled part of this layer.
@@ -37,7 +38,8 @@ add_fill_layer <- function(
                            fill_translate_anchor = NULL,
                            visibility = TRUE,
                            popup = NULL,
-                           id = "fill-layer") {
+                           id = "fill-layer",
+                           source_layer = NULL) {
   paint <- list(
     "fill-antialias" = fill_antialias,
     "fill-color" = fill_color,
@@ -51,7 +53,7 @@ add_fill_layer <- function(
     "fill-sort-key" = fill_sort_key,
     "visibility" = ifelse(visibility, "visible", "none")
   )
-  style <- create_layer_style(id, "fill", source, filter, paint, layout)
+  style <- create_layer_style(id, "fill", source, filter, paint, layout, source_layer)
   map %>%
     add_layer(style, popup)
 }

--- a/R/layers_line.R
+++ b/R/layers_line.R
@@ -50,7 +50,8 @@ add_line_layer <- function(map,
                            line_width = NULL,
                            visibility = NULL,
                            popup = NULL,
-                           id = "line-layer") {
+                           id = "line-layer",
+                           source_layer = NULL) {
   paint <- list(
     "line-blur" = line_blur,
     "line-color" = line_color,
@@ -72,7 +73,7 @@ add_line_layer <- function(map,
     "line-sort-key" = line_sort_key,
     "visibility" = ifelse(visibility, "visible", "none")
   )
-  style <- create_layer_style(id, "line", source, filter, paint, layout)
+  style <- create_layer_style(id, "line", source, filter, paint, layout, source_layer)
   map %>%
     add_layer(style, popup)
 }

--- a/R/styles.R
+++ b/R/styles.R
@@ -106,11 +106,12 @@ set_style <- function(map, style) {
   map
 }
 
-create_layer_style <- function(id, type, source, filter, paint, layout) {
+create_layer_style <- function(id, type, source, filter, paint, layout, source_layer) {
   list(
     id = id,
     type = type,
     source = source,
+    "source-layer" = source_layer,
     filter = filter,
     paint = purrr::compact(paint),
     layout = purrr::compact(layout)

--- a/man/add_circle_layer.Rd
+++ b/man/add_circle_layer.Rd
@@ -4,14 +4,27 @@
 \alias{add_circle_layer}
 \title{Add a circle layer to the map}
 \usage{
-add_circle_layer(map, source = NULL, filter = NULL,
-  circle_blur = NULL, circle_color = NULL, circle_opacity = NULL,
-  circle_pitch_alignment = NULL, circle_pitch_scale = NULL,
-  circle_radius = NULL, circle_sort_key = NULL,
-  circle_stroke_color = NULL, circle_stroke_opacity = NULL,
-  circle_stroke_width = NULL, circle_translate = NULL,
-  circle_translate_anchor = NULL, visibility = TRUE, popup = NULL,
-  id = "circle-layer")
+add_circle_layer(
+  map,
+  source = NULL,
+  filter = NULL,
+  circle_blur = NULL,
+  circle_color = NULL,
+  circle_opacity = NULL,
+  circle_pitch_alignment = NULL,
+  circle_pitch_scale = NULL,
+  circle_radius = NULL,
+  circle_sort_key = NULL,
+  circle_stroke_color = NULL,
+  circle_stroke_opacity = NULL,
+  circle_stroke_width = NULL,
+  circle_translate = NULL,
+  circle_translate_anchor = NULL,
+  visibility = TRUE,
+  popup = NULL,
+  source_layer = NULL,
+  id = "circle-layer"
+)
 }
 \arguments{
 \item{map}{A \link{mapboxer} object.}
@@ -55,6 +68,8 @@ One of "map", "viewport".}
 
 \item{popup}{A \href{https://github.com/janl/mustache.js}{mustache} template
 in which the tags refer to the properties of the layer's data object.}
+
+\item{source_layer}{The layer to use in the source for vector sources..}
 
 \item{id}{The unique id of the layer.}
 }

--- a/man/add_fill_layer.Rd
+++ b/man/add_fill_layer.Rd
@@ -4,12 +4,23 @@
 \alias{add_fill_layer}
 \title{Add a fill layer to the map}
 \usage{
-add_fill_layer(map, source = NULL, filter = NULL,
-  fill_antialias = TRUE, fill_color = NULL, fill_opacity = NULL,
-  fill_outline_color = NULL, fill_pattern = NULL,
-  fill_sort_key = NULL, fill_translate = NULL,
-  fill_translate_anchor = NULL, visibility = TRUE, popup = NULL,
-  id = "fill-layer")
+add_fill_layer(
+  map,
+  source = NULL,
+  filter = NULL,
+  fill_antialias = TRUE,
+  fill_color = NULL,
+  fill_opacity = NULL,
+  fill_outline_color = NULL,
+  fill_pattern = NULL,
+  fill_sort_key = NULL,
+  fill_translate = NULL,
+  fill_translate_anchor = NULL,
+  visibility = TRUE,
+  popup = NULL,
+  id = "fill-layer",
+  source_layer = NULL
+)
 }
 \arguments{
 \item{map}{A \link{mapboxer} object.}
@@ -48,6 +59,8 @@ One of "map", "viewport".}
 in which the tags refer to the properties of the layer's data object.}
 
 \item{id}{The unique id of the layer.}
+
+\item{source_layer}{The layer to use in the source for vector sources..}
 }
 \description{
 Add a fill layer to the map

--- a/man/add_line_layer.Rd
+++ b/man/add_line_layer.Rd
@@ -4,14 +4,31 @@
 \alias{add_line_layer}
 \title{Add a line layer to the map}
 \usage{
-add_line_layer(map, source = NULL, filter = NULL, line_blur = NULL,
-  line_cap = NULL, line_color = NULL, line_dasharray = NULL,
-  line_gap_width = NULL, line_gradient = NULL, line_join = NULL,
-  line_miter_limit = NULL, line_offset = NULL, line_opacity = NULL,
-  line_pattern = NULL, line_round_limit = NULL, line_sort_key = NULL,
-  line_translate = NULL, line_translate_anchor = NULL,
-  line_width = NULL, visibility = NULL, popup = NULL,
-  id = "line-layer")
+add_line_layer(
+  map,
+  source = NULL,
+  filter = NULL,
+  line_blur = NULL,
+  line_cap = NULL,
+  line_color = NULL,
+  line_dasharray = NULL,
+  line_gap_width = NULL,
+  line_gradient = NULL,
+  line_join = NULL,
+  line_miter_limit = NULL,
+  line_offset = NULL,
+  line_opacity = NULL,
+  line_pattern = NULL,
+  line_round_limit = NULL,
+  line_sort_key = NULL,
+  line_translate = NULL,
+  line_translate_anchor = NULL,
+  line_width = NULL,
+  visibility = NULL,
+  popup = NULL,
+  id = "line-layer",
+  source_layer = NULL
+)
 }
 \arguments{
 \item{map}{A \link{mapboxer} object.}
@@ -68,6 +85,8 @@ Features with a higher sort key will appear above features with a lower sort key
 in which the tags refer to the properties of the layer's data object.}
 
 \item{id}{The unique id of the layer.}
+
+\item{source_layer}{The layer to use in the source for vector sources..}
 }
 \description{
 Add a line layer to the map


### PR DESCRIPTION
Adding the source-layer parameter for vector tiles as per style specification.
The place of the parameter is not great: it would make sense for it to come next to "source", but it could be a breaking change for some people (changes the order)